### PR TITLE
Re-add support for excluded mod IDs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
+org.gradle.jvmargs=-Xmx3G
 neoforgeVersion=20.4.182
 parchmentVersion=2023.12.31
 parchmentMinecraftVersion=1.20.3

--- a/src/main/java/cpw/mods/forge/serverpacklocator/PackLocator.java
+++ b/src/main/java/cpw/mods/forge/serverpacklocator/PackLocator.java
@@ -73,7 +73,7 @@ public class PackLocator implements IModLocator
         }
 
         ModAccessor.setStatusLine("ServerPack: " + (successfulDownload ? "loaded" : "NOT loaded"));
-        return finalModList;
+        return serverPackLocator.processModList(finalModList);
     }
 
     private IModFile discoverInternalMod() {

--- a/src/main/java/cpw/mods/forge/serverpacklocator/client/ClientConfig.java
+++ b/src/main/java/cpw/mods/forge/serverpacklocator/client/ClientConfig.java
@@ -54,6 +54,8 @@ public class ClientConfig {
 
         private String remoteServer;
 
+        private List<String> excludedModIds = new ArrayList<>();
+
         @SpecNotNull
         private List<DownloadedServerContent> downloadedServerContent = new ArrayList<>();
 
@@ -67,6 +69,10 @@ public class ClientConfig {
 
         public List<DownloadedServerContent> getDownloadedServerContent() {
             return downloadedServerContent;
+        }
+
+        public List<String> getExcludedModIds() {
+            return excludedModIds;
         }
     }
 

--- a/src/main/java/cpw/mods/forge/serverpacklocator/client/ClientSidedPackHandler.java
+++ b/src/main/java/cpw/mods/forge/serverpacklocator/client/ClientSidedPackHandler.java
@@ -51,7 +51,8 @@ public class ClientSidedPackHandler extends SidedPackHandler<ClientConfig> {
 
     @Override
     protected List<IModLocator.ModFileOrException> processModList(List<IModLocator.ModFileOrException> scannedMods) {
-        return scannedMods;
+        var excludedModIds = getConfig().getClient().getExcludedModIds();
+        return scannedMods.stream().filter(modFile -> modFile.file() == null || modFile.file().getModInfos().stream().noneMatch(mod -> excludedModIds.contains(mod.getModId()))).toList();
     }
 
     @Override


### PR DESCRIPTION
The Gradle JVM arg change was necessary to get the project to build on my machine (otherwise it failed with `OutOfMemoryError`), so I included it.

The main focus of this PR is adding back the ability to exclude certain mod IDs from loading on the client.

Example usage:
```
[client]
	excludedModIds = ["roughlyenoughitems"]
```